### PR TITLE
Fix desktop file version

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,6 @@ Version needs updating in the following places:
 
 - **`org.libvips.vipsdisp.json`** needs the version number as a git tag.
 
-- **`org.libvips.vipsdisp.desktop`** also has a version number.
-
 ## flatpak
 
 Add the `flathub` repo:

--- a/org.libvips.vipsdisp.desktop
+++ b/org.libvips.vipsdisp.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=2.4
+Version=1.4
 Name=Vipsdisp
 GenericName=Image Viewer
 Comment=View large scientific images


### PR DESCRIPTION
The version refers to the version of the desktop-file-spec this
follows. The current version is 1.4.

See also `desktop-file-validate`.