### PR TITLE
Save options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+## 3.0.0, ??/??/??
+
+- save options menu
+
 ## 2.4.1, 21/8/22
 
 - remove stray printfs

--- a/src/imagewindow.h
+++ b/src/imagewindow.h
@@ -3,15 +3,17 @@
 
 #define IMAGE_WINDOW_TYPE (image_window_get_type())
 
-G_DECLARE_FINAL_TYPE( ImageWindow, image_window, 
+G_DECLARE_FINAL_TYPE( ImageWindow, image_window,
 	VIPSDISP, IMAGE_WINDOW, GtkApplicationWindow )
 
 ImageWindow *image_window_new( VipsdispApp *app );
 void image_window_open( ImageWindow *win, GFile *file );
 double image_window_get_scale( ImageWindow *win );
 TileSource *image_window_get_tile_source( ImageWindow *win );
+GFile *image_window_get_target_file( ImageWindow *win );
+GtkLabel *image_window_get_error_message_label( ImageWindow *win );
 void image_window_set_tile_source( ImageWindow *win, TileSource *tile_source );
-void image_window_get_mouse_position( ImageWindow *win, 
+void image_window_get_mouse_position( ImageWindow *win,
 	double *image_x, double *image_y );
 
 #endif /* __IMAGE_WINDOW_H */

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,7 @@ executable('vipsdisp', [
   'imagedisplay.c',
   'imagewindow.c',
   'infobar.c',
+  'saveoptions.c',
   'main.c',
   'tile.c',
   'tilecache.c',

--- a/src/saveoptions.c
+++ b/src/saveoptions.c
@@ -1,0 +1,659 @@
+#include "vipsdisp.h"
+
+#define DEFAULT_SPACING 10
+
+/* See the SaveOptions class interface file "saveoptions.h" for a high-level
+ * description of each SaveOptions class method.
+ */
+
+void
+save_options_free( SaveOptions *save_options )
+{
+	GtkWidget *it;
+
+	it = gtk_widget_get_first_child(
+		GTK_WIDGET( save_options->parent_box ) );
+	if ( it )
+		gtk_box_remove( save_options->parent_box, it );
+
+	g_free( save_options );
+}
+
+SaveOptions *
+save_options_new_empty()
+{
+	SaveOptions *save_options;
+
+	save_options = g_malloc( sizeof( SaveOptions ) );
+	save_options->parent_box = NULL;
+	save_options->image_window = NULL;
+	save_options->content_box = NULL;
+	save_options->row_count = 0;
+	save_options->error_message_label = NULL;
+
+	return save_options;
+}
+
+void
+save_options_init( SaveOptions *save_options,
+	GtkBox *parent_box, ImageWindow *image_window )
+{
+	GtkBox *content_box;
+
+	save_options->image_window = image_window;
+	content_box = GTK_BOX( gtk_box_new( GTK_ORIENTATION_VERTICAL,
+		0 ) );
+
+	save_options->content_box = content_box;
+	save_options->parent_box = parent_box;
+	save_options->error_message_label =
+		image_window_get_error_message_label( image_window );
+}
+
+SaveOptions *
+save_options_new( GtkBox *parent_box, ImageWindow *image_window )
+{
+	SaveOptions *save_options;
+		
+	save_options = save_options_new_empty();
+	save_options_init( save_options, parent_box, image_window );
+
+	return( save_options );
+}
+
+ImageWindow *
+save_options_get_image_window( SaveOptions *save_options )
+{
+	return save_options->image_window;
+}
+
+/* This is a helper function used by:
+ *
+ * 	save_options_build_save_operation_argument_map_fn
+ *
+ * to process a single property of the save operation.
+ *
+ * It sets the property to the value held by the user input widget pointed to
+ * by the widget iterator.
+ */
+static void
+save_options_build_save_operation_argument_map_fn_helper( GParamSpec *pspec,
+	VipsArgumentClass *argument_class, int *row_index,
+	SaveOptions *save_options, VipsObject *operation )
+{
+	VipsObjectClass *oclass;
+	GType otype = G_PARAM_SPEC_VALUE_TYPE( pspec );
+	GtkWidget *t, *grid, *grid_cell, *grid_cell_first_child;
+	const gchar *property_name;
+
+	/* Skip the sentinel, if there is one. See vips_rr
+	 */
+	if ( *row_index == save_options->row_count )
+		return;
+
+	/* For now, skip VipsImage and VipsObject types.
+	*/
+	if( g_type_is_a( otype, VIPS_TYPE_IMAGE ) )
+		return;
+	else if( g_type_is_a( otype, VIPS_TYPE_OBJECT ) &&
+		(oclass = g_type_class_ref( otype )) )
+		return;
+
+	property_name = g_param_spec_get_name( pspec );
+	grid = gtk_widget_get_first_child(
+		GTK_WIDGET( save_options->content_box ) );
+
+	/* Use the current value of the row_index to determine the next row. The
+	 * rows are attached in increasing index order, from top to bottom. Thus
+	 * the order of the widgets matches the order of the properties of the
+	 * VipsOperation, and the order of the widgets is always predictable.
+	 */
+	grid_cell = gtk_grid_get_child_at( GTK_GRID( grid ), 2, *row_index );
+
+	/* Peel off the layers of containing widgets to get to the user input widget
+	 * for the property in the iteration. The variable named
+	 * "grid_cell_first_child" holds a GtkBox widget. That widget contains
+	 * the actual user input widget we are interested in, which is held in
+	 * the variable "t", which stands for "temporary".
+	 */
+	grid_cell_first_child = gtk_widget_get_first_child( grid_cell );
+	t = gtk_widget_get_first_child( grid_cell_first_child );
+
+	/* Handle types that are not VipsImage or VipsObject.
+	 */
+	if( G_IS_PARAM_SPEC_STRING( pspec ) ) {
+		GtkEntryBuffer *buffer = gtk_text_get_buffer( GTK_TEXT( t ) );
+		const char* text = gtk_entry_buffer_get_text( buffer );
+		const char* none = "none";
+
+		if( !text || !strlen( text ) )
+			g_object_set( VIPS_OBJECT( operation ),
+				property_name, none,
+				NULL );
+	
+		else
+			g_object_set( VIPS_OBJECT( operation ),
+				property_name, text,
+				NULL );
+	}
+	else if( G_IS_PARAM_SPEC_BOOLEAN( pspec ) ) {
+		gboolean active = gtk_check_button_get_active( GTK_CHECK_BUTTON( t ) );
+		g_object_set( VIPS_OBJECT( operation ),
+			property_name, active,
+			NULL );
+	}
+	else if( G_IS_PARAM_SPEC_ENUM( pspec ) ) {
+		GParamSpecEnum *pspec_enum = G_PARAM_SPEC_ENUM( pspec );
+		int index = gtk_drop_down_get_selected( GTK_DROP_DOWN( t ) );
+		int value = pspec_enum->enum_class->values[index].value;
+		g_object_set( VIPS_OBJECT( operation ),
+			property_name, value,
+			NULL );
+	}
+	else if( G_IS_PARAM_SPEC_INT64( pspec ) ) {
+		gint64 value = (gint64) gtk_spin_button_get_value( GTK_SPIN_BUTTON( t ) );
+		g_object_set( VIPS_OBJECT( operation ),
+			property_name, value,
+			NULL );
+	}
+	else if( G_IS_PARAM_SPEC_INT( pspec )) {
+		gint64 value = (int) gtk_spin_button_get_value( GTK_SPIN_BUTTON( t ) );
+		g_object_set( VIPS_OBJECT( operation ),
+			property_name, value,
+			NULL );
+	}
+	else if( G_IS_PARAM_SPEC_UINT64( pspec ) ) {
+		guint64 value = (guint64) gtk_spin_button_get_value( GTK_SPIN_BUTTON( t ) );
+		g_object_set( VIPS_OBJECT( operation ),
+			property_name, value,
+			NULL );
+	}
+	else if( G_IS_PARAM_SPEC_DOUBLE( pspec ) ) {
+		gdouble value = gtk_spin_button_get_value( GTK_SPIN_BUTTON( t ) );
+		g_object_set( VIPS_OBJECT( operation ),
+			property_name, value,
+			NULL );
+	}
+	else if( G_IS_PARAM_SPEC_BOXED( pspec ) ) {
+		if( g_type_is_a( otype, VIPS_TYPE_ARRAY_INT ) ) {
+			int value;
+			VipsArrayInt *array_int;
+
+			value = (int) gtk_spin_button_get_value( GTK_SPIN_BUTTON( t ) );
+
+			/* For now just pretend every array-type parameter has
+			 * one element.
+			 * TODO handle arrays with two or more elements
+			 */
+			array_int = vips_array_int_newv( 1, value );
+
+			g_object_set( VIPS_OBJECT( operation ),
+				property_name, array_int,
+				NULL );
+		}
+		else if( g_type_is_a( otype, VIPS_TYPE_ARRAY_DOUBLE ) ) {
+			gdouble value;
+			VipsArrayDouble *array_double;
+			value = gtk_spin_button_get_value( GTK_SPIN_BUTTON( t ) );
+
+			/* For now just pretend every array-type parameter has
+			 * one element.
+			 * TODO handle arrays with two or more elements
+			 */
+			array_double = vips_array_double_newv( 1, value );
+			g_object_set( VIPS_OBJECT( operation ),
+				property_name, array_double,
+				NULL );
+		}
+		else if( g_type_is_a( otype, VIPS_TYPE_ARRAY_IMAGE ) ) {
+			/* Ignore VipsImage-type parameters for now.
+			 */
+			return;
+		}
+		else {
+			/* Ignore parameters of unrecognized type for now.
+			 */
+			return;
+		}
+	}
+	else {
+		printf( "Unknown type for \"%s\"", property_name );
+		return;
+	}
+
+	*row_index = *row_index + 1;
+}
+
+/* This is the function used by save_options_build_save_operation to process
+ * a single property of the save operation.
+ *
+ * See also save_options_build_save_operation_argument_map_fn_helper.
+ */
+static void *
+save_options_build_save_operation_argument_map_fn( VipsObject *operation,
+	GParamSpec *pspec, VipsArgumentClass *argument_class,
+	VipsArgumentInstance *argument_instance, void *a, void *b )
+{
+	VipsArgumentFlags flags = argument_class->flags;
+	int *row_index = (int *)a;
+	SaveOptions *save_options = (SaveOptions *)b;
+
+	/* Include arguments listed in the constructor.
+	 * Exclude required or deprecated arguments.
+	 */
+	if ( !(flags & VIPS_ARGUMENT_DEPRECATED) &&
+		(flags & VIPS_ARGUMENT_CONSTRUCT) &&
+		!(flags & VIPS_ARGUMENT_REQUIRED) )
+		save_options_build_save_operation_argument_map_fn_helper( pspec,
+			argument_class, row_index, save_options, operation );
+
+	return NULL;
+}
+
+void
+save_options_build_save_operation( SaveOptions *save_options,
+	VipsOperation *operation )
+{
+	gchar *filename;
+	int *row_index;
+
+	row_index = g_malloc( sizeof( int ) );
+
+	*row_index = 0;
+
+	g_object_get( G_OBJECT( operation ),
+		"filename", &filename, NULL );
+
+	/* Loop over the properties of the save operation. Apply the values from
+	 * each widget to the save operation.
+	 *
+	 * See also save_options_build_save_operation_argument_map_fn.
+	 */
+	vips_argument_map( VIPS_OBJECT( operation ),
+		save_options_build_save_operation_argument_map_fn,
+		row_index, save_options );
+	
+	g_free( row_index );
+}
+
+/* This function is used by:
+ *
+ * 	save_options_build_content_box_argument_map_fn_helper
+ *
+ * to process one property of the save operation. The property type and name
+ * are used to create a labelled user input element for that property.
+ */
+static void
+save_options_build_content_box_argument_map_fn_helper( GParamSpec *pspec,
+	VipsArgumentClass *argument_class, SaveOptions *save_options,
+	VipsObject *operation )
+{
+	VipsObjectClass *oclass;
+	GType otype = G_PARAM_SPEC_VALUE_TYPE( pspec );
+	const gchar *property_name;
+	GtkWidget *t, *label, *box, *label_box, *input_box, *grid;
+
+	/* Get the nickname of the property of the save operation currently
+	 * being processed. For VIPS, this is the user-facing name of the
+	 * property.
+	 */
+	property_name = g_param_spec_get_nick( pspec );
+
+	/* For now, skip properties of type VipsImage or VipsObject.
+	*/
+	if( g_type_is_a( otype, VIPS_TYPE_IMAGE ))
+		return;
+	else if( g_type_is_a( otype, VIPS_TYPE_OBJECT ) &&
+		(oclass = g_type_class_ref( otype )) )
+		return;
+
+	/* The GtkGrid widget is the first child of the save_options
+	 * content_box GtkBox.
+	 */
+	grid = gtk_widget_get_first_child( GTK_WIDGET( save_options->content_box ) );
+
+	/* Create the GtkBox widget containing the user input widget appropriate
+	 * for the current property. This box will contain another box, which
+	 * will in turn contain the user input widget.
+	 */
+	input_box = gtk_box_new( GTK_ORIENTATION_VERTICAL, 0 );
+
+	/* Add a user input widget for this property to the box. The widget
+	 * chosen depends on the type of the property. Set the initial value of
+	 * the user input widget to the default value for the property.
+	 */
+	if( G_IS_PARAM_SPEC_STRING( pspec ) ) {
+		GParamSpecString *pspec_string = G_PARAM_SPEC_STRING( pspec );
+		GtkEntryBuffer* buffer =
+			gtk_entry_buffer_new( pspec_string->default_value, -1 );
+
+		t = gtk_text_new_with_buffer( buffer );
+	}
+	else if( G_IS_PARAM_SPEC_BOOLEAN( pspec ) ) {
+		GParamSpecBoolean *pspec_boolean = G_PARAM_SPEC_BOOLEAN( pspec );
+		t = gtk_check_button_new();
+		gtk_check_button_set_active( GTK_CHECK_BUTTON( t ),
+			pspec_boolean->default_value );
+	}
+	else if( G_IS_PARAM_SPEC_ENUM( pspec ) ) {
+		GParamSpecEnum *pspec_enum = G_PARAM_SPEC_ENUM( pspec );
+		const char **property_nicknames =
+			g_malloc( (pspec_enum->enum_class->n_values + 1) * sizeof( char * ) );
+
+		for( int i = 0; i < pspec_enum->enum_class->n_values; ++i ) {
+			property_nicknames[i] =
+				pspec_enum->enum_class->values[i].value_nick;
+		}
+		property_nicknames[pspec_enum->enum_class->n_values] = NULL;
+		t = gtk_drop_down_new_from_strings( property_nicknames );
+		gtk_drop_down_set_selected( GTK_DROP_DOWN( t ),
+			pspec_enum->default_value );
+	}
+	else if( G_IS_PARAM_SPEC_INT64( pspec ) ) {
+		GParamSpecInt64 *pspec_int64 = G_PARAM_SPEC_INT64( pspec );
+		t = gtk_spin_button_new_with_range( pspec_int64->minimum,
+			pspec_int64->maximum, 1 );
+
+		gtk_spin_button_set_value( GTK_SPIN_BUTTON( t ),
+			(gint64)pspec_int64->default_value );
+	}
+	else if( G_IS_PARAM_SPEC_INT( pspec )) {
+		GParamSpecInt *pspec_int = G_PARAM_SPEC_INT( pspec );
+		t = gtk_spin_button_new_with_range( pspec_int->minimum,
+			pspec_int->maximum, 1 );
+
+		gtk_spin_button_set_value( GTK_SPIN_BUTTON( t ),
+			(int)pspec_int->default_value );
+	}
+	else if( G_IS_PARAM_SPEC_UINT64( pspec ) ) {
+		GParamSpecUInt64 *pspec_uint64 = G_PARAM_SPEC_UINT64( pspec );
+		t = gtk_spin_button_new_with_range( pspec_uint64->minimum,
+			pspec_uint64->maximum, 1 );
+
+		gtk_spin_button_set_value( GTK_SPIN_BUTTON( t ),
+			(guint64)pspec_uint64->default_value );
+	}
+	else if( G_IS_PARAM_SPEC_DOUBLE( pspec ) ) {
+		GParamSpecDouble *pspec_double = G_PARAM_SPEC_DOUBLE( pspec );
+
+		t = gtk_spin_button_new_with_range( pspec_double->minimum,
+			pspec_double->maximum, 1 );
+
+		gtk_spin_button_set_value( GTK_SPIN_BUTTON( t ),
+			pspec_double->default_value );
+	}
+	else if( G_IS_PARAM_SPEC_BOXED( pspec ) ) {	
+		if( g_type_is_a( otype, VIPS_TYPE_ARRAY_INT ) ) {
+			/* No default values exist for ParamSpecBoxed, so make
+			 * some up for now.
+			 */
+			t = gtk_spin_button_new_with_range( 0, 1000, 1 );
+			gtk_spin_button_set_value( GTK_SPIN_BUTTON( t ), 0 );
+		}
+		else if( g_type_is_a( otype, VIPS_TYPE_ARRAY_DOUBLE ) ) {
+			/* No default values exist for ParamSpecBoxed, so make
+			 * some up for now.
+			 */
+			t = gtk_spin_button_new_with_range( 0, 1000, .1 );
+			gtk_spin_button_set_value( GTK_SPIN_BUTTON( t ), 0 );
+		}
+		else if( g_type_is_a( otype, VIPS_TYPE_ARRAY_IMAGE ) ) {
+			/* Ignore VipsImage-type parameters for now.
+			 */
+			return;
+		}
+		else {
+			/* Ignore parameters of unrecognized type for now.
+			 */
+			return;
+		}
+	}
+	else {
+		printf("Unknown type for property \"%s\"\n", property_name);
+		g_object_ref_sink( input_box );
+		return;
+	}
+
+	/* Create a box to contain the user input widget "t", and add a tooltip
+	 * to the box. The tooltip contains the "blurb" for the property.
+	 * Make the user input widget "t" fill the box horizontally.
+	 * Append that container box to the "input_box".
+	 */
+	box = gtk_box_new( GTK_ORIENTATION_HORIZONTAL, 0 );
+	gtk_widget_set_tooltip_text( GTK_WIDGET( box ),
+		g_param_spec_get_blurb( pspec ) );
+
+	gtk_widget_set_hexpand( t, TRUE );
+	gtk_box_append( GTK_BOX( box ), t );
+	gtk_box_append( GTK_BOX( input_box ), box );
+
+	/* Attach the GtkBox "input_box" to the GtkGrid in the save_options
+	 * content_area. 
+	 */
+	gtk_grid_attach( GTK_GRID( grid ), input_box, 2,
+		save_options->row_count, 1, 1 );
+
+	/* Create the GtkBox widget containing the GtkLabel widget with the
+	 * user-facing name of the current property in the iteration.
+	 * Add a tooltip to the label. The tooltip is the same as before.
+	 */
+	label_box = gtk_box_new( GTK_ORIENTATION_VERTICAL, 0 );
+	gtk_widget_set_valign( label_box, GTK_ALIGN_CENTER );
+	label = gtk_label_new( property_name );
+	gtk_widget_set_hexpand( label, FALSE );
+	gtk_box_append( GTK_BOX( label_box ), label );
+	gtk_grid_attach( GTK_GRID( grid ), label_box, 0,
+		save_options->row_count, 1, 1 );
+
+	gtk_widget_set_tooltip_text( GTK_WIDGET( label ),
+		g_param_spec_get_blurb( pspec ) );
+
+	/* Increment the row_count.
+	 */
+	save_options->row_count += 1;
+}
+
+/* This is the function used by save_options_build_content_box to process a
+ * single property of the save operation.
+ *
+ * See also save_options_build_content_box_argument_map_fn_helper.
+ */
+static void *
+save_options_build_content_box_argument_map_fn( VipsObject *operation,
+	GParamSpec *pspec, VipsArgumentClass *argument_class,
+	VipsArgumentInstance *argument_instance, void *a, void *b )
+{
+	VipsArgumentFlags flags = argument_class->flags;
+	SaveOptions *save_options = (SaveOptions *)a;
+
+	/* Include arguments listed in the constructor.
+	 *
+	 * Exclude required or deprecated arguments.
+	 */
+	if ( !(flags & VIPS_ARGUMENT_DEPRECATED) &&
+		(flags & VIPS_ARGUMENT_CONSTRUCT) &&
+		!(flags & VIPS_ARGUMENT_REQUIRED) )
+		save_options_build_content_box_argument_map_fn_helper( pspec,
+			argument_class, save_options, operation );
+
+	return NULL;
+}
+
+void
+save_options_build_content_box( SaveOptions *save_options,
+	VipsOperation *operation )
+{
+	vips_argument_map( VIPS_OBJECT( operation ),
+		save_options_build_content_box_argument_map_fn,
+		save_options,
+		NULL);
+}
+
+/* Clean up the old content_box widget, and create a new one.
+ */
+static int
+save_options_reset_content_box( SaveOptions *save_options )
+{
+	GtkWidget *content_box, *grid;
+
+	content_box = GTK_WIDGET( save_options->content_box );
+	if ( content_box ) {
+		GtkWidget *it = gtk_widget_get_first_child(
+			GTK_WIDGET( save_options->parent_box ) );
+		if ( it )
+			gtk_box_remove( save_options->parent_box, it );
+	}
+
+	/* Create a new content box
+	 */
+	content_box = gtk_box_new( GTK_ORIENTATION_HORIZONTAL,
+		0 );
+
+	/* Give the save_options the pointer to the new content box.
+	 */
+	save_options->content_box = GTK_BOX( content_box );
+
+	/* Create a GtkGrid widget and append it to the save_options
+	 * content_box.
+	 */
+	grid = gtk_grid_new();
+	gtk_grid_set_row_spacing( GTK_GRID( grid ), 20 );
+	gtk_grid_set_column_spacing( GTK_GRID( grid ), 20 );
+	gtk_widget_set_margin_top( grid, 10 );
+	gtk_widget_set_margin_end( grid, 10 );
+	gtk_widget_set_margin_bottom( grid, 10 );
+	gtk_widget_set_margin_start( grid, 10 );
+	gtk_box_append( GTK_BOX( content_box ), grid );
+
+	/* Initialize the save_options row_count to zero.
+	 */
+	save_options->row_count = 0;
+
+	/* Return success code
+	 */
+	return 0;
+}
+
+/* Add a GtkInfoBar, containing an error message and a close button, at the
+ * top of the GtkFileChooser widget.
+ */
+void
+save_options_error_message_set( SaveOptions* save_options, char* err_msg )
+{
+	GtkWidget *saveoptions_win, *content_area, *info_bar;
+	GtkWindow *file_chooser_dialog;
+	char* markup;
+
+	/* The GtkFileChooser widget is the transient parent of the SaveOptions
+	 * window, which is the parent of the parent_box. Thus can get at the 
+	 * GtkFileChooser widget like so.
+	 */
+	saveoptions_win = gtk_widget_get_parent(
+		GTK_WIDGET( save_options->parent_box ) );
+
+	file_chooser_dialog =
+		gtk_window_get_transient_for( GTK_WINDOW( saveoptions_win ) );
+	
+	/* The content_area of the GtkFileChooser is the GtkBox to which custom
+	 * widgets can be added. It contains the GtkInfoBar as the first child.
+	 */
+	content_area = gtk_dialog_get_content_area(
+		GTK_DIALOG( file_chooser_dialog ) );
+
+	info_bar = gtk_widget_get_first_child( content_area );
+
+	/* Update the label markup with the new error message in bold text.
+	 */	
+	markup = g_markup_printf_escaped( "<b>%s</b>", err_msg );
+	gtk_label_set_markup( save_options->error_message_label, markup );
+
+	g_free( markup );
+
+	/* Reveal the GtkInfoBar.
+	 */
+	gtk_info_bar_set_revealed( GTK_INFO_BAR( info_bar ), TRUE );
+
+}
+
+int
+save_options_show( SaveOptions *save_options )
+{
+	GFile *target_file;
+	gchar *path, *filename_suffix, *operation_name;
+	VipsOperation *operation;
+	GtkWidget *scrolled_window;
+
+	/* Destroy the old save_options content_box, and create a new one.
+	 */
+	save_options_reset_content_box( save_options );
+
+	/* Grab the GFile to which we want to save the image loaded in the
+	 * image_window. The image_window holds a pointer to the GFile.
+	 */
+	target_file =
+		image_window_get_target_file( save_options->image_window );
+
+	/* Return an error code if the file path is incorrectly formatted.
+	 * Set the VIPS error buffer with a custom message. This is the
+	 * error you get when you don't include a file extension in the
+	 * file path.
+	 */
+	if( !(path = g_file_get_path( target_file ))
+		|| !(filename_suffix = strrchr( path, '.' ))
+		|| !(operation_name =
+			g_strdup_printf( "%ssave", ++filename_suffix )) )
+	{
+		vips_error( "vipsdisp", "File path is incorrectly formatted." );
+		return SAVE_OPTIONS_ERROR_PATH;
+	}
+
+	/* Return an error code if VIPS failed to create a save operation.
+	 * The VIPS error buffer will already hold the VIPS error message.
+	 * This error is the one you get when you use an invalid file
+	 * extension in the file path.
+	 */
+	if( !(operation = vips_operation_new( operation_name )) )
+		return SAVE_OPTIONS_ERROR_IMAGE_TYPE;
+	
+	/* Create the scrolled window that will contain the content box.
+	 */
+	scrolled_window = gtk_scrolled_window_new();
+
+	/* Set the scrolled window's policy so that a vertical scrollbar always
+	 * appears.
+	 */
+	gtk_scrolled_window_set_policy( GTK_SCROLLED_WINDOW( scrolled_window ),
+		GTK_POLICY_NEVER,
+		GTK_POLICY_ALWAYS );
+
+	/* Set the minimum height of the scrolled window.
+	*/
+	gtk_scrolled_window_set_min_content_height(
+		GTK_SCROLLED_WINDOW( scrolled_window ),
+		400);
+
+	/* Set the maximum height of the scrolled window.
+	*/
+	gtk_scrolled_window_set_max_content_height(
+		GTK_SCROLLED_WINDOW( scrolled_window ),
+		500);
+
+	/* Make the save_options content_box the child of the scrolled window.
+	*/
+	gtk_scrolled_window_set_child( GTK_SCROLLED_WINDOW( scrolled_window ),
+		GTK_WIDGET( save_options->content_box ) );
+
+	/* Append the scrolled window to the parent box.
+	 */
+	gtk_box_append( save_options->parent_box, scrolled_window );
+
+	/* Dynamically fill the content box with labels and user input widgets,
+	 * based on the properties of the desired image file type for the save
+	 * operation.
+	 */
+	save_options_build_content_box( save_options, operation );
+
+	/* Return EXIT_SUCCESS code.
+	 */
+	return 0;
+}

--- a/src/saveoptions.h
+++ b/src/saveoptions.h
@@ -1,0 +1,103 @@
+#ifndef __SAVEOPTIONS_H
+#define __SAVEOPTIONS_H
+
+/* The SaveOptions class holds
+ *
+ * 	- widgets that manage and display the VIPS save options for a particular
+ *	  VipsForeignSave object. ( These widgets are dynamically generated, by
+ *	  iterating over the properties of the corresponding VipsOperation,
+ *	  using the VIPS API for introspection. )
+ *
+ *	- as well as the count of the number of rows held by the GtkGrid widget
+ *	  that holds the user input fields and their labels, once the grid has
+ *        been dynamically built.
+ */
+typedef struct SaveOptions SaveOptions;
+struct SaveOptions {
+	/* This is the widget that contains the image window. The parent_box is
+	 * passed to the SaveOptions constructor.
+	 */
+	GtkBox *parent_box;
+
+	/* This is the widget responsible for loading, displaying, and saving
+	 * images We use it to actually perform the save operation once data
+	 * is collected from the user using the dynamically generated save
+	 * options menu.
+	 */
+	ImageWindow *image_window;
+
+	/* This is the widget that contains the grid of user inputs, where each
+	 * row contains a label and an input widget that depends on the type of
+	 * the property being introspected. Each label is the user-facing name
+	 * of the property being introspected.
+	 */
+	GtkBox *content_box;
+
+	/* The count of the number of rows currently in the GtkGrid widget
+	 * within the content_box widget. As the grid is dynamically generated,
+	 * the row_count is incremented. It is used as the grid row index in
+	 * calls to gtk_grid_attach, as we iterate over the properties of
+	 * the VipsForeignSave object.
+	 */
+	int row_count;
+
+	/* The label containing the most recent VIPS error message related to
+	 * the save options.
+	 */
+	GtkLabel *error_message_label;
+};
+
+/* Result codes used by SaveOptions methods ( currently, just
+ * save_options_show ).
+ */
+typedef enum {
+	SAVE_OPTIONS_SUCCESS = 0,
+	SAVE_OPTIONS_ERROR_PATH = -1,
+	SAVE_OPTIONS_ERROR_IMAGE_TYPE = -2,
+} SAVE_OPTIONS_RESULT;
+
+/* Clean up the SaveOptions object.
+ */
+void save_options_free( SaveOptions * );
+
+/* Allocate space for a new SaveOptions object with NULL or zeroed members.
+ */
+SaveOptions * save_options_new_empty();
+
+/* Initialize a newly allocated "empty" SaveOptions object ( created with
+ * save_options_new_empty ) with a parent_box widget and an image_window widget.
+ */
+void save_options_init( SaveOptions *save_options, GtkBox *parent_box, ImageWindow *image_window );
+
+/* Create a new SaveOptions object ( allocating space for it first ).
+ */
+SaveOptions * save_options_new( GtkBox *parent_box, ImageWindow *image_window );
+
+/* Get a pointer to the ImageWindow object held by the SaveOptions object.
+ */
+ImageWindow * save_options_get_image_window( SaveOptions * );
+
+/* Iterate over the rows of the grid of user input widgets, and use the values
+ * entered by the user to build the VipsOperation for the VipsForeignSave
+ * associated with the image format we want to Save As. The VipsOperation
+ * argument must be previously allocated, and its "filename" and "in" properties
+ * must already be initialized.
+ */
+void save_options_build_save_operation( SaveOptions *, VipsOperation * );
+
+/* Present the save options menu to the user.
+ */
+int save_options_show( SaveOptions * );
+
+/* Iterate over the properties of the VipsOperation to dynamically generate
+ * the grid of user input widgets for the save options for the VipsForeginSave
+ * associated with the desired image format.
+ */
+void save_options_build_content_area( SaveOptions *save_options, VipsOperation *operation );
+
+/* Update the error message for the save options menu, and reveal it in the
+ * saveas dialog.
+ */
+void save_options_error_message_set( SaveOptions *, char * );
+
+#endif /* __SAVEOPTIONS_H */

--- a/src/saveoptions.h
+++ b/src/saveoptions.h
@@ -52,8 +52,7 @@ struct SaveOptions {
  */
 typedef enum {
 	SAVE_OPTIONS_SUCCESS = 0,
-	SAVE_OPTIONS_ERROR_PATH = -1,
-	SAVE_OPTIONS_ERROR_IMAGE_TYPE = -2,
+	SAVE_OPTIONS_ERROR_IMAGE_TYPE = -1,
 } SAVE_OPTIONS_RESULT;
 
 /* Clean up the SaveOptions object.

--- a/src/tilesource.c
+++ b/src/tilesource.c
@@ -1883,17 +1883,17 @@ tile_source_get_file( TileSource *tile_source )
 }
 
 int
-tile_source_write_to_file( TileSource *tile_source, GFile *file )
+tile_source_write_to_file( TileSource *tile_source, VipsOperation *operation )
 {
-	char *path;
 	int result;
 
-	if( !(path = g_file_get_path( file )) )
-		return( -1 );
+	vips_image_set_progress( tile_source->image, TRUE );
 
-	vips_image_set_progress( tile_source->image, TRUE ); 
-	result = vips_image_write_to_file( tile_source->image, path, NULL );
-	g_free( path );
+	g_object_set( VIPS_OBJECT( operation ),
+		"in", tile_source->image,
+		NULL );
+
+	result = vips_cache_operation_buildp( &operation );
 
 	return( result );
 }

--- a/src/tilesource.h
+++ b/src/tilesource.h
@@ -21,15 +21,15 @@
  *	images. Pages can have subifd pyramids. Includes single-page images.
  *	Reload on page change.
  *
- * PAGE_PYRAMID 
+ * PAGE_PYRAMID
  *
  *	"page" param is pyr levels. We load a single page and reload on
  *	magnification change.
  *
  * TOILET_ROLL
  *
- *	All pages are the identical, so we open as a single, tall, thin strip 
- *	and the viewer does any presenting as pages / animation / etc. during 
+ *	All pages are the identical, so we open as a single, tall, thin strip
+ *	and the viewer does any presenting as pages / animation / etc. during
  *	conversion to the screen display image.
  *	These images can have subifd pyramids.
  */
@@ -96,7 +96,7 @@ typedef struct _TileSource {
 	VipsImage *base;
 
 	/* The image we are displaying, and something to fetch pixels from it
-	 * with. 
+	 * with.
 	 */
 	VipsImage *image;
 	VipsRegion *image_region;
@@ -125,13 +125,13 @@ typedef struct _TileSource {
 	int n_delay;
 	double zoom;
 
-	/* If all the pages are the same size and format, we can load as a 
+	/* If all the pages are the same size and format, we can load as a
 	 * toilet roll.
 	 */
 	gboolean pages_same_size;
 
 	/* If all the pages are the same size and format, and also all mono,
-	 * we can display pages as bands. 
+	 * we can display pages as bands.
 	 */
 	gboolean all_mono;
 
@@ -195,7 +195,7 @@ typedef struct _TileSourceClass {
 	void (*posteval)( TileSource *tile_source, VipsProgress *progress );
 
 	/* Everything has changed, so image geometry and pixels. Perhaps a
-	 * new page in a multi-page TIFF where pages change in size. 
+	 * new page in a multi-page TIFF where pages change in size.
 	 */
 	void (*changed)( TileSource *tile_source );
 
@@ -224,11 +224,11 @@ int tile_source_fill_tile( TileSource *tile_source, Tile *tile );
 
 const char *tile_source_get_path( TileSource *tile_source );
 GFile *tile_source_get_file( TileSource *tile_source );
-int tile_source_write_to_file( TileSource *tile_source, GFile *file );
+int tile_source_write_to_file( TileSource *tile_source, VipsOperation *operation );
 
 VipsImage *tile_source_get_image( TileSource *tile_source );
 VipsImage *tile_source_get_base_image( TileSource *tile_source );
-gboolean tile_source_get_pixel( TileSource *tile_source, 
+gboolean tile_source_get_pixel( TileSource *tile_source,
 	double **vector, int *n, int x, int y );
 TileSource *tile_source_duplicate( TileSource *tile_source );
 

--- a/src/vipsdisp.h
+++ b/src/vipsdisp.h
@@ -24,7 +24,7 @@
  */
 #define TILE_SIZE (256)
 
-/* Cache size -- enough for two 4k displays. 
+/* Cache size -- enough for two 4k displays.
  */
 #define MAX_TILES (2 * (4096 / TILE_SIZE) * (2048 / TILE_SIZE))
 
@@ -38,6 +38,7 @@
 #include "imagedisplay.h"
 #include "imagewindow.h"
 #include "infobar.h"
+#include "saveoptions.h"
 #include "displaybar.h"
 
 #endif /* __VIPSDISP_H */


### PR DESCRIPTION
New save options menu!

Uses introspection on the VIPS save operation, to choose the appropriate widgets and text to display for a given output image format.

Also removed trailing white space in imagesource.c and tilesource.c (while removing them from my own code with regex). I can  redact those changes though if desired though.