### PR TITLE
Fix previous/next page icon on win32

### DIFF
--- a/src/gtk/imagewindow.ui
+++ b/src/gtk/imagewindow.ui
@@ -25,12 +25,12 @@
       <item>
         <attribute name="label">Previous page</attribute>
         <attribute name="action">win.prev</attribute>
-        <attribute name="verb-icon">media-seek-backward</attribute>
+        <attribute name="verb-icon">go-previous-symbolic</attribute>
       </item>
       <item>
         <attribute name="label">Next page</attribute>
         <attribute name="action">win.next</attribute>
-        <attribute name="verb-icon">media-seek-forward</attribute>
+        <attribute name="verb-icon">go-next-symbolic</attribute>
       </item>
     </section>
 


### PR DESCRIPTION
Prefer the use of `go-previous-symbolic` and `go-next-symbolic` icons over `media-seek-backward` and `media-seek-forward`, as the former icons are available in GTK's default icon theme: https://gitlab.gnome.org/GNOME/gtk/-/tree/4.13.2/gtk/icons/scalable/actions

This would avoid having to depend on the Adwaita icon theme.

See: https://gitlab.gnome.org/GNOME/gtk/-/issues/3794