### PR TITLE
imagewindow: Avoid use of GtkFileChooser* when GTK >= 4.10

### DIFF
--- a/src/vipsdisp.h
+++ b/src/vipsdisp.h
@@ -28,7 +28,7 @@
  */
 #define MAX_TILES (2 * (4096 / TILE_SIZE) * (2048 / TILE_SIZE))
 
-/* We use various gtk4 features (filechooser, dialog) which are going away 
+/* We use various gtk4 features (GtkInfoBar, GtkDialog) which are going away
  * in gtk5.
  */
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS


### PR DESCRIPTION
The GtkFileChooser APIs are deprecated in favor of the new GtkFileDialog API.