### PR TITLE
Fix build after libvips/libvips#4004

### DIFF
--- a/src/gtkutil.c
+++ b/src/gtkutil.c
@@ -18,7 +18,7 @@ set_gentryv(GtkWidget *edit, const char *fmt, va_list ap)
 	if (!fmt)
 		fmt = "";
 
-	(void) vips_vsnprintf(buf, 1000, fmt, ap);
+	(void) g_vsnprintf(buf, 1000, fmt, ap);
 
 	/* Filter out /n and /t ... they confuse gtkentry terribly
 	 */

--- a/src/tilesource.c
+++ b/src/tilesource.c
@@ -1550,9 +1550,9 @@ tilesource_new_from_file(const char *filename)
 		for (level = 0; level < level_count; level++) {
 			char name[256];
 
-			vips_snprintf(name, 256, "openslide.level[%d].width", level);
+			g_snprintf(name, 256, "openslide.level[%d].width", level);
 			tilesource->level_width[level] = get_int(base, name, 0);
-			vips_snprintf(name, 256, "openslide.level[%d].height", level);
+			g_snprintf(name, 256, "openslide.level[%d].height", level);
 			tilesource->level_height[level] = get_int(base, name, 0);
 		}
 


### PR DESCRIPTION
The deprecated string functions were moved to the `deprecated/` directory, which implicitly means you'll need to include `vips/vips7compat.h` to use them.


<details>
  <summary>Details</summary>

```
[1/3] Compiling C object src/vipsdisp.p/gtkutil.c.o
FAILED: src/vipsdisp.p/gtkutil.c.o 
gcc -Isrc/vipsdisp.p -Isrc -I../src -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/cairo -I/usr/include/Imath -I/usr/include/cfitsio -I/usr/include/webp -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/sysprof-6 -I/usr/include/libxml2 -I/usr/include/pixman-1 -I/usr/include/fribidi -I/usr/include/librsvg-2.0 -I/usr/include/libpng16 -I/usr/include/OpenEXR -I/usr/include/openjpeg-2.5 -I/usr/include/nifti -I/usr/include/gtk-4.0 -I/usr/include/graphene-1.0 -I/usr/lib64/graphene-1.0/include -I. -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -O3 -DHAVE_CONFIG_H -O3 -mfpmath=sse -msse -msse2 -pthread -DHWY_SHARED_DEFINE -DWITH_GZFILEOP -MD -MQ src/vipsdisp.p/gtkutil.c.o -MF src/vipsdisp.p/gtkutil.c.o.d -o src/vipsdisp.p/gtkutil.c.o -c ../src/gtkutil.c
../src/gtkutil.c: In function ‘set_gentryv’:
../src/gtkutil.c:21:16: error: implicit declaration of function ‘vips_vsnprintf’; did you mean ‘g_vsnprintf’? [-Wimplicit-function-declaration]
   21 |         (void) vips_vsnprintf(buf, 1000, fmt, ap);
      |                ^~~~~~~~~~~~~~
      |                g_vsnprintf
[2/3] Compiling C object src/vipsdisp.p/tilesource.c.o
FAILED: src/vipsdisp.p/tilesource.c.o 
gcc -Isrc/vipsdisp.p -Isrc -I../src -I/usr/include/pango-1.0 -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/cairo -I/usr/include/Imath -I/usr/include/cfitsio -I/usr/include/webp -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/sysprof-6 -I/usr/include/libxml2 -I/usr/include/pixman-1 -I/usr/include/fribidi -I/usr/include/librsvg-2.0 -I/usr/include/libpng16 -I/usr/include/OpenEXR -I/usr/include/openjpeg-2.5 -I/usr/include/nifti -I/usr/include/gtk-4.0 -I/usr/include/graphene-1.0 -I/usr/lib64/graphene-1.0/include -I. -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -O3 -DHAVE_CONFIG_H -O3 -mfpmath=sse -msse -msse2 -pthread -DHWY_SHARED_DEFINE -DWITH_GZFILEOP -MD -MQ src/vipsdisp.p/tilesource.c.o -MF src/vipsdisp.p/tilesource.c.o.d -o src/vipsdisp.p/tilesource.c.o -c ../src/tilesource.c
../src/tilesource.c: In function ‘tilesource_new_from_file’:
../src/tilesource.c:1553:25: error: implicit declaration of function ‘vips_snprintf’; did you mean ‘vips_shrinkv’? [-Wimplicit-function-declaration]
 1553 |                         vips_snprintf(name, 256, "openslide.level[%d].width", level);
      |                         ^~~~~~~~~~~~~
      |                         vips_shrinkv
ninja: build stopped: subcommand failed.
```
</details>