### PR TITLE
Meson: fix feature detect for `gtk_snapshot_set_snap()`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ add_project_arguments('-I.', language: 'c')
 
 gtk_dep = dependency('gtk4', version: '>=4.14')
 # use this to fix tile alignment, not yet merged
-config_h.set('HAVE_GTK_SNAPSHOT_SET_SNAP', cc.has_header_symbol('gtk.h', 'gtk_snapshot_set_snap', dependencies: gtk_dep))
+config_h.set('HAVE_GTK_SNAPSHOT_SET_SNAP', cc.has_function('gtk_snapshot_set_snap', prefix: '#include <gtk/gtk.h>', dependencies: gtk_dep))
 
 configure_file(
   output: 'config.h',

--- a/src/tilecache.c
+++ b/src/tilecache.c
@@ -941,7 +941,6 @@ tilecache_snapshot(Tilecache *tilecache, GtkSnapshot *snapshot,
 
 			graphene_rect_t bounds;
 
-			// +1 to hide tile boundaries
 			bounds.origin.x = tile->bounds0.left * scale - x + paint->origin.x;
 			bounds.origin.y = tile->bounds0.top * scale - y + paint->origin.y;
 			bounds.size.width = tile->bounds0.width * scale;
@@ -953,7 +952,7 @@ tilecache_snapshot(Tilecache *tilecache, GtkSnapshot *snapshot,
 			 */
 			bounds.size.width += 1;
 			bounds.size.height += 1;
-#endif /*HAVE_GTK_SNAPSHOT_SET_SNAP*/
+#endif /*!HAVE_GTK_SNAPSHOT_SET_SNAP*/
 
 			gtk_snapshot_append_scaled_texture(snapshot,
 				tile_get_texture(tile), filter, &bounds);


### PR DESCRIPTION
```diff
-Header "gtk.h" has symbol "gtk_snapshot_set_snap" with dependency gtk4: NO 
+Checking for function "gtk_snapshot_set_snap" with dependency gtk4: YES 
```

Tested using this changeset: https://github.com/libvips/build-win64-mxe/compare/HEAD...revise-gtk-patches.