### PR TITLE
Meson: update comment for `gtk_snapshot_set_snap()`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
 add_project_arguments('-I.', language: 'c')
 
 gtk_dep = dependency('gtk4', version: '>=4.14')
-# use this to fix tile alignment, not yet merged
+# use this to fix tile alignment, added in 4.23.1
 config_h.set('HAVE_GTK_SNAPSHOT_SET_SNAP', cc.has_function('gtk_snapshot_set_snap', prefix: '#include <gtk/gtk.h>', dependencies: gtk_dep))
 
 configure_file(


### PR DESCRIPTION
It will be available in GTK 4.23.1, see:
https://blogs.gnome.org/gtk/2026/05/28/snapping/
https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9844

Windows test branch here: https://github.com/libvips/build-win64-mxe/tree/gtk-mr-9844